### PR TITLE
Reduce command set load time

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The canvas is remembered on a per application basis, so you do not have to respe
 The canvas specifying commands can be found in canvas.talon.
 
 # Position Specifiers
-Position specifiers are ways to specify positions to commands. Some commands will number positions. Those positions can be specified by number. Locations on the alpha grid (see below) are specified with the phonetic alphabet words corresponding to the letters in vertical, horizontal order. Positions on the current graph are specified by how many tick marks to move along each axis each separated by the word by (for example: minus five by ten means five tick marks to the left and ten tick marks up on a standard two dimensional graph).
+Position specifiers are ways to specify positions to commands. Some commands will number positions. Those positions can be specified by number. Locations on the alpha grid (see below) are specified with the phonetic alphabet words corresponding to the letters in vertical, horizontal order. Positions on the current graph are specified by how many tick marks to move along each axis each separated by the word by (for example: minus five by ten means five tick marks to the left and ten tick marks up on a standard two dimensional graph). The number of tick marks can be specified with a decimal number that can be positive or negative, but the numbers on both sides of the decimal point can only be between 0 and 99 in magnitude.
 
  Saying "move" followed by a position specifier moves the cursor to the specified position.
  

--- a/number_captures.py
+++ b/number_captures.py
@@ -36,10 +36,24 @@ def diagram_drawing_small_decimal_number(m) -> str:
     return number
 
 @module.capture(rule = '<number_small>|<user.diagram_drawing_small_decimal_number>')
-def diagram_drawing_small_float(m)-> float:
+def diagram_drawing_small_positive_number(m)-> str:
     ''''''
     try:
-        return float(m.diagram_drawing_small_decimal_number)
+        return m.diagram_drawing_small_decimal_number
     except:
         pass
-    return float(m.number_small)
+    return str(m.number_small)
+
+@module.capture(rule = '[dash|minus|negative] <user.diagram_drawing_small_positive_number>')
+def diagram_drawing_small_number(m) -> str:
+    ''''''
+    result: str = m[0]
+    if len(m) == 2:
+        result = '-' + m[1]
+    return result
+
+@module.capture(rule = '<user.diagram_drawing_small_number>')
+def diagram_drawing_small_float(m) -> float:
+    ''''''
+    result: float = float(m.diagram_drawing_small_number)
+    return result

--- a/number_captures.py
+++ b/number_captures.py
@@ -19,11 +19,8 @@ def diagram_drawing_positive_number(m) -> str:
 @module.capture(rule = '[dash|minus|negative] <user.diagram_drawing_positive_number>')
 def diagram_drawing_number(m) -> str:
     ''''''
-    result: str = m[0]
-    if len(m) == 2:
-        result = '-' + m[1]
-    return result
-
+    return compute_signed_number_string_for_capture(m)
+    
 @module.capture(rule = '<user.diagram_drawing_number>')
 def diagram_drawing_number_float(m) -> float:
     ''''''
@@ -47,13 +44,16 @@ def diagram_drawing_small_positive_number(m)-> str:
 @module.capture(rule = '[dash|minus|negative] <user.diagram_drawing_small_positive_number>')
 def diagram_drawing_small_number(m) -> str:
     ''''''
-    result: str = m[0]
-    if len(m) == 2:
-        result = '-' + m[1]
-    return result
+    return compute_signed_number_string_for_capture(m)
 
 @module.capture(rule = '<user.diagram_drawing_small_number>')
 def diagram_drawing_small_float(m) -> float:
     ''''''
     result: float = float(m.diagram_drawing_small_number)
+    return result
+
+def compute_signed_number_string_for_capture(m):
+    result: str = m[0]
+    if len(m) == 2:
+        result = '-' + m[1]
     return result

--- a/number_captures.py
+++ b/number_captures.py
@@ -29,3 +29,17 @@ def diagram_drawing_number_float(m) -> float:
     ''''''
     result: float = float(m.diagram_drawing_number)
     return result
+
+@module.capture(rule = '<number_small> (point|dot) <number_small>')
+def diagram_drawing_small_decimal_number(m) -> str:
+    number: str = str(m[0]) + '.' + str(m[2])
+    return number
+
+@module.capture(rule = '<number_small>|<user.diagram_drawing_small_decimal_number>')
+def diagram_drawing_small_float(m)-> float:
+    ''''''
+    try:
+        return float(m.diagram_drawing_small_decimal_number)
+    except:
+        pass
+    return float(m.number_small)

--- a/position_captures.py
+++ b/position_captures.py
@@ -4,7 +4,7 @@ from .fire_chicken.mouse_position import MousePosition
 PositionSpecifier = Union[int, List, str]
 
 module = Module()
-@module.capture(rule = '<number>|<user.diagram_drawing_number_float> by <user.diagram_drawing_number_float> [by <user.diagram_drawing_number_float>]|<user.letter> <user.letter>')
+@module.capture(rule = '<number>|<user.diagram_drawing_small_float> by <user.diagram_drawing_small_float> [by <user.diagram_drawing_small_float>]|<user.letter> <user.letter>')
 def diagram_drawing_position_specifier(m) -> PositionSpecifier:
     ''''''
     try:


### PR DESCRIPTION
Reduce how long the command set takes to load by using number small instead of number for the tick mark positions in the position specifiers.